### PR TITLE
Preparations for iOS13:

### DIFF
--- a/DEjson.podspec
+++ b/DEjson.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DEjson"
-  s.version      = "4.0.0"
+  s.version      = "5.0.0"
   s.summary      = "JSON parser and serializer in pure swift."
   s.description  = <<-DESC
                     Error resilient JSON parser and serializer in pure swift.
@@ -13,11 +13,11 @@ Pod::Spec.new do |s|
   s.author             = { "Johannes Schriewer" => "j.schriewer@anfe.ma" }
   s.social_media_url   = "http://twitter.com/dunkelstern"
 
-  s.ios.deployment_target = "8.0"
-  s.osx.deployment_target = "10.10"
-
-  s.source       = { :git => "https://github.com/anfema/DEjson.git", :tag => "4.0.0" }
+  s.ios.deployment_target = "13.0"
+  s.osx.deployment_target = "11.0"
+  s.swift_version = '5.5'
+  
+  s.source       = { :git => "https://github.com/anfema/DEjson.git", :tag => "5.0.0" }
   s.source_files  = "Sources/*.swift"
 
-  s.swift_version = '5.0'
 end

--- a/DEjson.xcodeproj/project.pbxproj
+++ b/DEjson.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5CFA71FA276B7DB1003B77B7 /* DEjson.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = DEjson.podspec; sourceTree = "<group>"; };
+		5CFA71FB276B7DB1003B77B7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		8F499FD21BA19F1F00E1AC15 /* DEjson.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DEjson.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F499FD51BA19F1F00E1AC15 /* DEjson.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DEjson.h; sourceTree = "<group>"; };
 		8F499FD71BA19F1F00E1AC15 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -101,6 +103,8 @@
 		8F499FC81BA19F1F00E1AC15 = {
 			isa = PBXGroup;
 			children = (
+				5CFA71FB276B7DB1003B77B7 /* README.md */,
+				5CFA71FA276B7DB1003B77B7 /* DEjson.podspec */,
 				8F4DD9461BEA5C7B000F917A /* LICENSE.txt */,
 				8F499FD41BA19F1F00E1AC15 /* Sources */,
 				8F499FE01BA19F2000E1AC15 /* Tests */,
@@ -239,7 +243,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1310;
 				ORGANIZATIONNAME = anfema;
 				TargetAttributes = {
 					8F499FD11BA19F1F00E1AC15 = {
@@ -392,6 +396,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -417,7 +422,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -451,6 +457,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -470,7 +477,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -494,7 +502,8 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = OSX/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.anfema.DEjson.ios;
@@ -518,7 +527,8 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = OSX/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.anfema.DEjson.ios;
@@ -569,7 +579,6 @@
 				INFOPLIST_FILE = OSX/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.anfema.DEjson.osx;
 				PRODUCT_NAME = DEjson;
 				SDKROOT = macosx;
@@ -591,7 +600,6 @@
 				INFOPLIST_FILE = OSX/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.anfema.DEjson.osx;
 				PRODUCT_NAME = DEjson;
 				SDKROOT = macosx;

--- a/DEjson.xcodeproj/xcshareddata/xcschemes/DEjson OSX.xcscheme
+++ b/DEjson.xcodeproj/xcshareddata/xcschemes/DEjson OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,8 +26,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8FC26A141BB9435D00E38569"
+            BuildableName = "DEjson.framework"
+            BlueprintName = "DEjson_osx"
+            ReferencedContainer = "container:DEjson.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -40,17 +49,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8FC26A141BB9435D00E38569"
-            BuildableName = "DEjson.framework"
-            BlueprintName = "DEjson_osx"
-            ReferencedContainer = "container:DEjson.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -71,8 +69,6 @@
             ReferencedContainer = "container:DEjson.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/DEjson.xcodeproj/xcshareddata/xcschemes/DEjson iOS.xcscheme
+++ b/DEjson.xcodeproj/xcshareddata/xcschemes/DEjson iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8F499FD11BA19F1F00E1AC15"
+            BuildableName = "DEjson.framework"
+            BlueprintName = "DEjson_ios"
+            ReferencedContainer = "container:DEjson.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8F499FD11BA19F1F00E1AC15"
-            BuildableName = "DEjson.framework"
-            BlueprintName = "DEjson_ios"
-            ReferencedContainer = "container:DEjson.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:DEjson.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ Error resilient JSON parser and serializer in pure swift
 
 ## Requirements
 
-- iOS 8.0+ / macOS 10.10+
-- Xcode 8.2+
-- Swift 3.0+
+- iOS 13.0+ / macOS 11.0+
+- Xcode 13.2+
+- Swift 5.5+
 
 ## Note
 
 For Swift 2.2 or 2.3 support, use Tags < 2.0.0
+For Swift 4 support, use Tags < 5.0.0
 

--- a/Sources/JSONEncoder.swift
+++ b/Sources/JSONEncoder.swift
@@ -140,8 +140,8 @@ open class JSONEncoder {
                     let low = UInt8(c.value & 0xff)
                     
                     // This is so convoluted because of Swift compiler bug on iOS 8.4 (works simpler on 9.0+)
-                    var highString = self.makeHexString(high)
-                    var lowString = self.makeHexString(low)
+                    let highString = self.makeHexString(high)
+                    let lowString = self.makeHexString(low)
                     var lowGen = lowString.unicodeScalars.makeIterator()
                     var highGen = highString.unicodeScalars.makeIterator()
                     result.append(String(highGen.next()!))


### PR DESCRIPTION
- Updated project settings
- Updated schemes
- Increased minimum deployment target to iOS 13.0 and macos 11.0
- Updated podspec
- Updated Readme
- Fixed linter warnings